### PR TITLE
chore: fix link name

### DIFF
--- a/docs/about-this-documentation.md
+++ b/docs/about-this-documentation.md
@@ -21,7 +21,7 @@ hide_title: true
 
 ## 导览
 
-要全面了解如何将 MobX 与 React 一起使用，请通读当前的 _Introduction_ 标题，特别是 [MobX 的要点](the-gist-of-mobx.md)。它将向您介绍最重要的原则、API以及它们之间的关系。看完这个，你应该就可以使用 MobX 了！
+要全面了解如何将 MobX 与 React 一起使用，请通读当前的 _Introduction_ 标题，特别是 [MobX 主旨](the-gist-of-mobx.md)。它将向您介绍最重要的原则、API以及它们之间的关系。看完这个，你应该就可以使用 MobX 了！
 
 接着，你可以看看这里的推荐内容：
 


### PR DESCRIPTION
侧边栏中没有 `MobX 的要点`， 只有一个 `Mobx 主旨`，不相同的文案可能会导致误解

<!--
    非常感谢您参与Mobx中文文档的翻译工作！ 🙌

    👋 如果您是从zh.mobx.js.org的翻译按钮跳转到Github提交PR的同学，请确认当前页面文档无人翻译！前往issues查看[https://github.com/mobxjs/zh.mobx.js.org/issues]

    👋 如果您是准备对已翻译文档进行纠错，请继续提交您的PR

    👋 如果您是从issues区认领之后进行翻译的，请直接删除或者忽略这个[PULL_REQUEST_TEMPLATE.md]
-->