### PR TITLE
chore: correct anchor link

### DIFF
--- a/docs/actions.md
+++ b/docs/actions.md
@@ -200,7 +200,7 @@ class Doubler {
 -   `runInAction(fn)`
 
 使用这个工具函数来创建一个会被立即调用的临时 action。在异步进程中非常有用。
-请查看 [上面代码块](#examples) 中的实例。
+请查看 [上面代码块](#例子) 中的实例。
 
 ## Actions 和继承
 

--- a/docs/observable-state.md
+++ b/docs/observable-state.md
@@ -26,7 +26,7 @@ hide_title: true
 
 这个函数可以捕获_已经存在_的对象属性并且使得它们可观察。任何 JavaScript 对象（包括类的实例）都可以作为 `target` 被传递给这个函数。
 一般情况下，`makeObservable` 是在类的构造函数中调用的，并且它的第一个参数是 `this` 。
-`annotations` 参数将会为每一个成员映射 [注解](#available-annotations)。需要注意的是，当使用 [装饰器](enabling-decorators.md) 时，`annotations` 参数将会被忽略。
+`annotations` 参数将会为每一个成员映射 [注解](#可用的注解)。需要注意的是，当使用 [装饰器](enabling-decorators.md) 时，`annotations` 参数将会被忽略。
 
 派生数据并且接受参数的方法（例如：`findUsersOlderThan(age: number): User[]`）不需要任何注解。
 当我们从一个 reaction 中调用它们时，它们的读取操作仍然会被跟踪，但是为了避免内存泄漏，它们的输出将不会被记忆化。更详细的信息可以查看 [MobX-utils computedFn {🚀}](https://github.com/mobxjs/mobx-utils#computedfn)。
@@ -149,7 +149,7 @@ tags.push("prio: for fun")
 同样，你可以传入一个 `overrides` 对象来为特定的成员提供特定的注解。
 查看上面的代码获取示例。
 
-由 `observable` 返回的对象将会使用 Proxy 包装，这意味着之后被添加到这个对象中的属性也将被侦测并使其转化为可观察对象（除非禁用 [proxy](configuration.md#proxy-support)）。
+由 `observable` 返回的对象将会使用 Proxy 包装，这意味着之后被添加到这个对象中的属性也将被侦测并使其转化为可观察对象（除非禁用 [proxy](configuration.md#proxy-选项)）。
 
 `observable` 方法也可以被像 [arrays](api.md#observablearray)，[Maps](api.md#observablemap) 和 [Sets](api.md#observableset) 这样的集合调用。这些集合也将被克隆并转化为可观察对象。
 
@@ -231,14 +231,14 @@ MobX 无法使原始值可观察，因为它们在 JavaScript 中是不可变的
 | `computed.struct`                  | 类似于 `computed`，但如果重新计算后的结果在结构上与之前的结果相等，那么观察者将不会收到通知。 |
 | `true`                             | 推断最佳注解。查看 [makeAutoObservable](#makeautoobservable) 获取更多信息。 |
 | `false`                            | 刻意不为该属性指定注解。                                       |
-| `flow`                             | 创建一个 `flow` 管理异步进程。查看 [flow](actions.md#using-flow-instead-of-async--await-) 获取更多信息。需要注意的是，推断出来的 TypeScript 返回类型可能会出错。 不可写。 |
+| `flow`                             | 创建一个 `flow` 管理异步进程。查看 [flow](actions.md#使用-flow-代替-async--await-) 获取更多信息。需要注意的是，推断出来的 TypeScript 返回类型可能会出错。 不可写。 |
 | `flow.bound`                       | 类似于 flow, 但是会将 flow 绑定到实例，因此将始终设置 `this`。 不可写。    |       
 | `override`                         | [用于子类覆盖继承的 `action`，`flow`，`computed`，`action.bound`](subclassing.md)。 |
 | `autoAction`                       | 不应被显式调用，但 `makeAutoObservable` 内部会对其进行调用，以便根据调用上下文将方法标识为 action 或者派生值。 |
 
 ## 局限性
 
-1. `make(Auto)Observable` 仅支持已经定义的属性。请确保你的 [**编译器选项**是正确的](installation.md#use-spec-compliant-transpilation-for-class-properties)，或者，作为权宜之计，确保在你使用 `make(Auto)Observable` 之前已经为所有属性赋了值。如果没有正确的配置，已经声明而未初始化的字段（例如：`class X { y; }`）将无法被正确侦测到。
+1. `make(Auto)Observable` 仅支持已经定义的属性。请确保你的 [**编译器选项**是正确的](installation.md#对类属性使用符合规范的转换)，或者，作为权宜之计，确保在你使用 `make(Auto)Observable` 之前已经为所有属性赋了值。如果没有正确的配置，已经声明而未初始化的字段（例如：`class X { y; }`）将无法被正确侦测到。
 1. `makeObservable` 只能注解由其本身所在的类定义声明出来的属性。如果一个子类或超类引入了可观察字段，那么该子类或超类就必须自己为那些属性调用 `makeObservable`。
 1. `options` 参数只能提供一次。被传入的 `options` 是 _“有粘性”_ 的，之后无法更改（例如，在 [子类](subclassing.md) 中）。
 1. **每个字段只能被注解一次**（`override` 除外）。字段注解和配置不能在 [子类](subclassing.md) 中改变。

--- a/docs/react-integration.md
+++ b/docs/react-integration.md
@@ -253,7 +253,7 @@ React.render(<TimerView secondsPassed={myTimer.secondsPassed} />, document.body)
 通过`observer`包裹的组件 _只可以_ 订阅到在 _他们自己_ 渲染的期间的可观察对象. 如果要将可观察对象 objects / arrays / maps 传递到子组件中, 他们必须被 `observer` 包裹。
 通过callback回调的组件也是一样。
 
-如果你非要传递可观察对象到未被`observer`包裹的组件中， 要么是因为它是第三方组件，要么你需要组件对Mobx无感知，那你必须 [转换可观察对象为显式 （convert the observables to plain JavaScript values or structures）](observable-state.md#converting-observables-back-to-vanilla-javascript-collections) 在传递前阅读这篇文章。
+如果你非要传递可观察对象到未被`observer`包裹的组件中， 要么是因为它是第三方组件，要么你需要组件对Mobx无感知，那你必须在传递前 [转换可观察对象为显式 （convert the observables to plain JavaScript values or structures）](observable-state.md#将-observable-转换回普通的-javascript-集合) 。
 
 关于上述的详细描述,
 可以看一下下面的使用 `todo` 对象的例子， 一个 `TodoView` (observer)组件和一个虚构的接收一组对象映射入参的不是`observer`的`GridRow`组件：

--- a/docs/the-gist-of-mobx.md
+++ b/docs/the-gist-of-mobx.md
@@ -225,5 +225,5 @@ Mobx 使用单向数据流，利用 _action_ 改变 _state_ ，进而更新所�
 
 ## 提示
 
-如果您发现很难适应 MobX 的心智模型，请将其配置为严格模式，在运行时偏离这些模式的情况下将会发出警告。更多信息请查看[linting MobX](configuration.md#linting-options)章节。
+如果您发现很难适应 MobX 的心智模型，请将其配置为严格模式，在运行时偏离这些模式的情况下将会发出警告。更多信息请查看[linting MobX](configuration.md#代码lint选项)章节。
 


### PR DESCRIPTION
锚点链接需要转换为对应中文，才能在点击时正确定位
<!--
    非常感谢您参与Mobx中文文档的翻译工作！ 🙌

    👋 如果您是从zh.mobx.js.org的翻译按钮跳转到Github提交PR的同学，请确认当前页面文档无人翻译！前往issues查看[https://github.com/mobxjs/zh.mobx.js.org/issues]

    👋 如果您是准备对已翻译文档进行纠错，请继续提交您的PR

    👋 如果您是从issues区认领之后进行翻译的，请直接删除或者忽略这个[PULL_REQUEST_TEMPLATE.md]
-->