### PR TITLE
fix(api.md): misspelled words

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -26,7 +26,7 @@ _把事物转化成 observable。_
 
 [**用法**](observable-state.md#makeobservable)：`makeObservable(target, annotations?, options?)`
 
-属性、整个对象、数组、Maps 和 Sets 都可以被转化成 obervable。
+属性、整个对象、数组、Maps 和 Sets 都可以被转化成 observable。
 
 ### `makeAutoObservable`
 


### PR DESCRIPTION
第29行，应为'observable'。
In 29，'obervable' should be 'observable'。

<!--
    非常感谢您参与Mobx中文文档的翻译工作！ 🙌

    👋 如果您是从zh.mobx.js.org的翻译按钮跳转到Github提交PR的同学，请确认当前页面文档无人翻译！前往issues查看[https://github.com/mobxjs/zh.mobx.js.org/issues]

    👋 如果您是准备对已翻译文档进行纠错，请继续提交您的PR

    👋 如果您是从issues区认领之后进行翻译的，请直接删除或者忽略这个[PULL_REQUEST_TEMPLATE.md]
-->