### PR TITLE
chore: fix outdated link of mobx-react-lite

### DIFF
--- a/docs/react-integration.md
+++ b/docs/react-integration.md
@@ -18,7 +18,7 @@ const MyComponent = observer(props => ReactElement)
 
 MobX 可以独立于 React 运行, 但是他们通常是结合在一起使用, 在 [Mobx的宗旨（The gist of MobX）](the-gist-of-mobx.md) 一文中你会经常看见集成React最重要的一部分：用于包裹React Component的 `observer` [HOC](https://reactjs.org/docs/higher-order-components.html)方法。
 
-`observer` 是你可以自主选择的，[在安装时（during installation）](installation.md#installation)独立提供的 React bindings 包。 在下面的例子中,我们将使用更加轻量的[`mobx-react-lite` 包](https://github.com/mobxjs/mobx-react-lite)。
+`observer` 是你可以自主选择的，[在安装时（during installation）](installation.md#installation)独立提供的 React bindings 包。 在下面的例子中,我们将使用更加轻量的[`mobx-react-lite` 包](https://github.com/mobxjs/mobx/tree/main/packages/mobx-react-lite)。
 
 ```javascript
 import React from "react"


### PR DESCRIPTION
The link of mobx-react-lite points to [the outdated repository](https://github.com/mobxjs/mobx-react-lite) rather than [the current repository](https://github.com/mobxjs/mobx/tree/main/packages/mobx-react-lite), and the English website has fixed the problem.